### PR TITLE
feat: 필터링 조회 기능 구현 완료

### DIFF
--- a/src/main/java/com/woowa/gather/controller/PostController.java
+++ b/src/main/java/com/woowa/gather/controller/PostController.java
@@ -75,10 +75,10 @@ public class PostController {
                                                               @RequestParam(required = false) List<Age> ages,
                                                               @RequestParam(required = false) List<Gender> genders) {
 
-        // foodTypes, ages, genders 쿼리 파라미터 null 체크 및 처리
-        if (foodTypes == null) foodTypes = new ArrayList<>();
-        if (ages == null) ages = new ArrayList<>();
-        if (genders == null) genders = new ArrayList<>();
+//        // foodTypes, ages, genders 쿼리 파라미터 null 체크 및 처리
+//        if (foodTypes == null) foodTypes = new ArrayList<>();
+//        if (ages == null) ages = new ArrayList<>();
+//        if (genders == null) genders = new ArrayList<>();
 
 //        // foodTypes 상태 logging
 //        if (foodTypes != null) {

--- a/src/main/java/com/woowa/gather/service/PostReadService.java
+++ b/src/main/java/com/woowa/gather/service/PostReadService.java
@@ -18,9 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 @Service
 @Transactional(readOnly = true)
@@ -53,57 +55,67 @@ public class PostReadService {
         // 기본 Specification : ONGOING 상태
         Specification<Post> baseSpec = PostSpecification.findPostsEqualPostStatus(PostStatus.ONGOING);
 
-        List<Specification<Post>> dateSpec = new ArrayList<>(); // 모임 날짜 필터링 Specification
-        List<Specification<Post>> foodTypeSpec = new ArrayList<>(); // 냠냠 유형 필터링 Specification
+        Specification<Post> resultDateSpec = combineDateSpecs(dateTypes); // 모임 날짜 Specification
+        Specification<Post> resultFoodTypeSpec = combineTagSpecs(foodTypes, PostSpecification::findPostsEqualFoodType); // 냠냠 유형 Specification
+        Specification<Post> resultAgeSpec = combineTagSpecs(ages, PostSpecification::findPostsEqualAge); // 연령대 Specification
+        Specification<Post> resultGenderSpec = combineTagSpecs(genders, PostSpecification::findPostsEqualGender); // 성별 Specification
 
-        // 모임 날짜 필터링
-        if (dateTypes != null) {
-            LocalDateTime startOfToday = LocalDate.now().atStartOfDay(); // Today 00:00:00
-            LocalDateTime endOfToday = LocalDate.now().atTime(23, 59, 59); // Today 23:59:59
-            LocalDateTime startOfThisSaturday = startOfToday.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY)); // This Saturday 00:00:00
-            LocalDateTime endOfThisSunday = startOfThisSaturday.plusDays(1).withHour(23).withMinute(59).withSecond(59); // This Sunday 23:59:59
-
-            // dateType [0: 오늘 / 1: 내일 / 2: 이번 주말]
-            for (Integer dateType : dateTypes) {
-                switch (dateType) {
-                    case 0:
-                        dateSpec.add(PostSpecification.findPostsBetweenDates(startOfToday, endOfToday));
-                        break;
-                    case 1:
-                        dateSpec.add(PostSpecification.findPostsBetweenDates(startOfToday.plusDays(1), endOfToday.plusDays(1)));
-                        break;
-                    case 2:
-                        dateSpec.add(PostSpecification.findPostsBetweenDates(startOfThisSaturday, endOfThisSunday));
-                        break;
-                    default:
-                        continue;
-                }
-            }
-        }
-
-        // 냠냠 유형 필터링
-        if (foodTypes != null) {
-            for (FoodType foodType : foodTypes) {
-                foodTypeSpec.add(PostSpecification.findPostsEqualFoodType(foodType));
-            }
-        }
-
-        // dateSpec의 각 Specification을 or로 결합
-        Specification<Post> dateCombinedSpec = dateSpec.stream()
-                .reduce(Specification::or)
-                .map(baseSpec::and)
-                .orElse(baseSpec);
-
-        // foodTypeSpec의 각 Specification을 or로 결합
-        Specification<Post> foodTypeCombinedSpec = foodTypeSpec.stream()
-                .reduce(Specification::or)
-                .map(baseSpec::and)
-                .orElse(baseSpec);
-
-        // 최종 결과: (baseSpec and dateSpec) and (baseSpecfood and TypeSpecs)
-        Specification<Post> resultSpec = dateCombinedSpec.and(foodTypeCombinedSpec);
+        Specification<Post> resultSpec = baseSpec;
+        if (resultDateSpec != null) resultSpec = resultSpec.and(resultDateSpec);
+        if (resultFoodTypeSpec != null) resultSpec = resultSpec.and(resultFoodTypeSpec);
+        if (resultAgeSpec != null) resultSpec = resultSpec.and(resultAgeSpec);
+        if (resultGenderSpec != null) resultSpec = resultSpec.and(resultGenderSpec);
 
         return postRepository.findAll(resultSpec);
+    }
+
+    // 각 Specification을 or로 결합
+    private <T> Specification<Post> combineTagSpecs(List<T> filters, Function<T, Specification<Post>> specFunction) {
+        return filters == null ? null : filters.stream()
+                .map(specFunction)
+                .reduce(Specification::or)
+                .orElse(null);
+    }
+
+    private Specification<Post> combineDateSpecs(List<Integer> dateTypes) {
+        if (dateTypes == null || dateTypes.isEmpty()) {
+            return null;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start = null;
+        LocalDateTime end = null;
+
+        List<Specification<Post>> specs = new ArrayList<>();
+
+        // dateType 0: 오늘 / 1: 내일 / 2: 이번 주말
+        for (Integer dateType : dateTypes) {
+            switch (dateType) {
+                case 0:
+                    start = now.with(LocalTime.MIN); // Today 00:00:00
+                    end = now.with(LocalTime.MAX); // Today 23:59:59
+                    break;
+                case 1:
+                    start = now.plusDays(1).with(LocalTime.MIN);
+                    end = now.plusDays(1).with(LocalTime.MAX);
+                    break;
+                case 2:
+                    start = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY)).with(LocalTime.MIN); // This Saturday 00:00:00
+                    end = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).with(LocalTime.MAX); // This Sunday 23:59:59
+                    break;
+                default:
+                    continue;
+            }
+
+            if (start != null && end != null) {
+                Specification<Post> spec = PostSpecification.findPostsBetweenDates(start, end);
+                specs.add(spec);
+            }
+        }
+
+        return specs.stream()
+                .reduce(Specification::or)
+                .orElse(null);
     }
 
 }


### PR DESCRIPTION
- 필터링 파라미터 : dateTypes, foodTypes, ages, genders
  - 다중 선택 가능
- 필터링 파라미터 없음 : ONGOING 상태의 게시물 전체 조회 (메인 페이지 default)